### PR TITLE
docs(todo): icebox the copy-mode statusline notifier

### DIFF
--- a/.vim/pack/zzz-settings/start/settings/after/plugin/statusline.vim
+++ b/.vim/pack/zzz-settings/start/settings/after/plugin/statusline.vim
@@ -141,6 +141,13 @@ function! YASL_Warnings()
     call add(l:warnings, g:yasl.warnings.paste_mode)
   endif
 
+  " ICEBOX: add a COPY-mode statusline notifier segment here, mirroring the
+  " paste-mode [PASTE] indicator above — light up when the planned COPY-mode
+  " toggle (the copytoggle.vim "steal", see docs/todo.md "Toggles") is active.
+  " Deferred to icebox 2026-07-23 at the user's request (revisit on request);
+  " hoisted from docs/todo.md "Toggles > COPY mode toggle: add a statusline
+  " notifier".
+
   " Join all warnings with a space
   return join(l:warnings, ' ')
 endfunction

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -25,8 +25,6 @@ This seems like it has issues.
 Steal
 [this](https://github.com/timakro/vim-copytoggle/blob/master/plugin/copytoggle.vim).
 
-Add a statusline notifier.
-
 ## Universal keybinds
 
 ### error/warning (and other) navigation


### PR DESCRIPTION
## Summary
- Remove the one-line "Add a statusline notifier" item from `docs/todo.md` (under *Toggles > COPY mode toggle*) at the user's request.
- Relocate its intent to a keyword-dense `ICEBOX:` marker in the YASL statusline config, beside the existing paste-mode `[PASTE]` warning it would mirror (revisit on request).

Part of a cross-repo statusline-icebox sweep (dotagents backlog #39, dotfiles #308).

## Test plan
- [x] `ICEBOX:` marker sits inside `YASL_Warnings()` beside the paste-mode block; comment-only, no behaviour change
- [x] Comment lines wrap ≤ 78 cols; todo line cleanly removed (no double blank)